### PR TITLE
Fix for a variable that under certain circumstances may be undefined.

### DIFF
--- a/nz/co/ventego-creative/raygun4cfml/RaygunExceptionMessage.cfc
+++ b/nz/co/ventego-creative/raygun4cfml/RaygunExceptionMessage.cfc
@@ -62,7 +62,10 @@ limitations under the License.
 
 			returnContent["className"] = arguments.issueDataStruct.type;
 			returnContent["catchingMethod"] = "error struct";
-			returnContent["message"] = arguments.issueDataStruct.diagnostics;
+			returnContent["message"] = "";
+			if (StructKeyExists(arguments.issueDataStruct,"diagnostics")) {
+				returnContent["message"] = arguments.issueDataStruct.diagnostics;
+			}
 			returnContent["stackTrace"] = stackTraceData;
 			returnContent["fileName"] = "";
 			returnContent["innerError"] = "";


### PR DESCRIPTION
If an exception is thrown due to a missing method in a CFC, the diagnostic key/value in the exception structure isn't present. This checks to see that the key/value exists, and if so assigns the value to another variable.
